### PR TITLE
simple HEADLESS caveat

### DIFF
--- a/pixoo/__init__.py
+++ b/pixoo/__init__.py
@@ -7,7 +7,12 @@ from PIL import Image, ImageOps
 
 from ._colors import Palette
 from ._font import retrieve_glyph
-from .simulator import Simulator, SimulatorConfig
+
+HEADLESS_NO_SIMULATOR = False
+try:
+    from .simulator import Simulator, SimulatorConfig
+except ImportError:
+    HEADLESS_NO_SIMULATOR = True
 
 
 def clamp(value, minimum=0, maximum=255):
@@ -68,7 +73,7 @@ class Pixoo:
     __simulator = None
 
     def __init__(self, address, size=64, debug=False, refresh_connection_automatically=True, simulated=False,
-                 simulation_config=SimulatorConfig()):
+                simulation_config=None if HEADLESS_NO_SIMULATOR else SimulatorConfig()):
         assert size in [16, 32, 64], \
             'Invalid screen size in pixels given. ' \
             'Valid options are 16, 32, and 64'
@@ -97,7 +102,7 @@ class Pixoo:
 
         # We're going to need a simulator
         if self.simulated:
-            self.__simulator = Simulator(self, simulation_config)
+            self.__simulator = None if HEADLESS_NO_SIMULATOR else Simulator(self, simulation_config)
 
     def clear(self, rgb=Palette.BLACK):
         self.fill(rgb)


### PR DESCRIPTION
`try...except` on the required simulator import in `pixoo/__init__.py` to set  a `HEADLESS_NO_SIMULATOR` flag in the module to skip instantiating with the classes we're not importing. This is a workaround for skipping importing tkinter, like on a headless raspberry pi (no X windows and python-tk installed) 

I believe this closes the loop on the intended behavior according to the docs, stating `python-tk|python3-tk` is optional.